### PR TITLE
Part II: More of Renaming the Native Coin to "CNTC", and "Solana" to …

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.76.0"
+channel = "1.81.0"

--- a/sdk/program/Cargo.toml
+++ b/sdk/program/Cargo.toml
@@ -9,7 +9,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
-rust-version = "1.75.0" # solana platform-tools rust version
+rust-version = "1.81.0" # solana platform-tools rust version
 
 [dependencies]
 bincode = { workspace = true }


### PR DESCRIPTION
…"Centicrypt". Bumping the Rustc Toolchain version to 1.81.0

#### Problem


#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
