### PR TITLE
Amending DEFAULT_TICKS_PER_SECOND, DEFAULT_TICKS_PER_SLOT, and DEFAUL…

### DIFF
--- a/sdk/program/src/clock.rs
+++ b/sdk/program/src/clock.rs
@@ -25,7 +25,7 @@ use solana_sdk_macro::CloneZeroed;
 /// The default tick rate that the cluster attempts to achieve (160 per second).
 ///
 /// Note that the actual tick rate at any given time should be expected to drift.
-pub const DEFAULT_TICKS_PER_SECOND: u64 = 80; //160; //Reduced for slower execution
+pub const DEFAULT_TICKS_PER_SECOND: u64 = 40; //160; //Reduced for slower execution
 
 #[cfg(test)]
 static_assertions::const_assert_eq!(MS_PER_TICK, 6);
@@ -39,10 +39,10 @@ pub const SLOT_MS: u64 = DEFAULT_MS_PER_SLOT;
 
 // At 160 ticks/s, 64 ticks per slot implies that leader rotation and voting will happen
 // every 400 ms. A fast voting cadence ensures faster finality and convergence
-pub const DEFAULT_TICKS_PER_SLOT: u64 = 128; //64;
+pub const DEFAULT_TICKS_PER_SLOT: u64 = 256; //64;
 
 // GCP n1-standard hardware and also a xeon e5-2520 v4 are about this rate of hashes/s
-pub const DEFAULT_HASHES_PER_SECOND: u64 = 1_000_000; //2_000_000;
+pub const DEFAULT_HASHES_PER_SECOND: u64 = 500_000; //2_000_000;
 
 // Empirical sampling of mainnet validator hash rate showed the following stake
 // percentages can exceed the designated hash rates as of July 2023:


### PR DESCRIPTION
…T_HASHES_PER_SECOND for a slower blocks creation and bigger ticks per slot to make the slot longer. Making it now 4x slower than regular Solana network throughput.

#### Problem


#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
